### PR TITLE
feat: add pricing data to single fund pages

### DIFF
--- a/containers/Fund/CombinedFund.tsx
+++ b/containers/Fund/CombinedFund.tsx
@@ -3,8 +3,6 @@ import Link from 'next/link';
 import Breadcrumb from '@/components/Breadcrumbs';
 import Button, { Size as ButtonSize } from '@/components/Button';
 import useMessage from '@/hooks/message';
-import useAxios from 'axios-hooks';
-import { useIntl } from 'react-intl';
 import Icon, { Icons, Size as IconSize } from '@/components/Icon';
 import FundStatus from '@/components/FundStatus';
 import trimAddress from '@/utils/trimAddress';
@@ -13,29 +11,13 @@ import { useFundsContext } from '@/contexts/funds';
 import FundGroup from '@/components/FundGroup';
 import Pill from '@/components/Pill';
 import { FundProps } from './types';
+import usePrice from '@/hooks/price';
 
 const CombinedFund = ({ fundKey, ...fund }: FundProps) => {
-  const intl = useIntl();
   const vaults = useVaultsContext();
   const funds = useFundsContext();
   const [supportingFunds, setSupportingFunds] = useState([]);
-  const [price, setPrice] = useState(null);
-  // @TODO move to a usePrice (or useCovalent) hook
-  const [{ data }] = useAxios({
-    url: `https://api.covalenthq.com/v1/pricing/historical_by_address/1/usd/${fund.fundToken.address}/`,
-  });
-
-  useEffect(() => {
-    const latestPrice = data?.data?.prices[0]?.price;
-    if (latestPrice) {
-      setPrice(
-        intl.formatNumber(latestPrice, {
-          style: 'currency',
-          currency: 'USD',
-        })
-      );
-    }
-  }, [data]);
+  const price = usePrice(fund.fundToken.address);
 
   useEffect(() => {
     if (vaults.length && funds.length) {

--- a/containers/Fund/SingleFund.tsx
+++ b/containers/Fund/SingleFund.tsx
@@ -18,6 +18,8 @@ import {
 import useMessage from '@/hooks/message';
 import type { FundProps } from './types';
 import { Asset } from '@/types/asset';
+import usePrice from '@/hooks/price';
+import { FormattedMessage } from 'react-intl';
 
 const SingleFund = ({
   holdings,
@@ -32,6 +34,8 @@ const SingleFund = ({
   const [offset, setOffset] = useState(0);
   const [collection, setCollection] = useState([]);
   const [value, setValue] = useState('');
+  const price = usePrice(fundToken.address);
+
   const url = useMemo(() => {
     const tokenIds = holdings.slice(offset, limit).join('&token_ids=');
     if (tokenIds) {
@@ -109,10 +113,18 @@ const SingleFund = ({
                   className="h-10 w-10"
                 />
               </div>
-              <div className="flex flex-col text-left">
+              <div className="mr-4 flex flex-col text-left">
                 <dt>{useMessage('fund.detail.supply')}</dt>
                 <dd className="font-bold text-xl">{holdings.length}</dd>
               </div>
+              {!!price && (
+                <div className="mr-4 flex-col text-left">
+                  <dt>
+                    <FormattedMessage id="fund.detail.price" />
+                  </dt>
+                  <dd className="font-bold text-xl">{price}</dd>
+                </div>
+              )}
             </dl>
           </header>
           <aside className="text-right flex flex-col justify-end items-end">

--- a/containers/Home/Home.tsx
+++ b/containers/Home/Home.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Link from 'next/link';
 import Head from 'next/head';
-import { FormattedNumber } from 'react-intl';
 import useMessage from '@/hooks/message';
 import FundGroup, { Columns } from '@/components/FundGroup';
 import Poster from '@/components/Poster';

--- a/hooks/price.ts
+++ b/hooks/price.ts
@@ -1,0 +1,28 @@
+import useAxios from 'axios-hooks';
+import { useEffect, useState } from 'react';
+import { useIntl } from 'react-intl';
+
+const usePrice = (address: string) => {
+  const [price, setPrice] = useState(null);
+  const intl = useIntl();
+
+  const [{ data }] = useAxios({
+    url: `https://api.covalenthq.com/v1/pricing/historical_by_address/1/usd/${address}/`,
+  });
+
+  useEffect(() => {
+    const latestPrice = data?.data?.prices[0]?.price;
+    if (latestPrice) {
+      setPrice(
+        intl.formatNumber(latestPrice, {
+          style: 'currency',
+          currency: 'USD',
+        })
+      );
+    }
+  }, [data]);
+
+  return price;
+};
+
+export default usePrice;

--- a/lang/en.json
+++ b/lang/en.json
@@ -60,6 +60,7 @@
   "fund.loading": "Loading fund data...",
   "fund.error": "Failed to load fund data :(",
   "fund.detail.supply": "Supply",
+  "fund.detail.price": "Price",
   "fund.cta.invest": "Buy {fund}",
   "fund.cta.mintRedeem": "Mint or redeem {token}",
   "fund.meta.title": "{fund} | NFTX",


### PR DESCRIPTION
Refactor out the covalent price endpoint into a hook and use it on the single and combined fund pages to show latest price (if it has one).