### PR TITLE
feat: use meta object for buy url

### DIFF
--- a/components/VaultCard/adapters/AssetCard.tsx
+++ b/components/VaultCard/adapters/AssetCard.tsx
@@ -23,7 +23,7 @@ const AssetCard = (
     <DefaultVaultCard
       className={props.className}
       eyebrow={props.asset_contract.name}
-      image={props.image_url}
+      image={props.image_preview_url}
       title={props.name}
       // seems to come through as hex without the hex
       background={props.background_color ? `#${props.background_color}` : null}

--- a/containers/Fund/SingleFund.tsx
+++ b/containers/Fund/SingleFund.tsx
@@ -28,6 +28,7 @@ const SingleFund = ({
   isFinalized,
   vaultId,
   fundKey,
+  meta,
 }: FundProps) => {
   const { asPath } = useRouter();
   const [limit, setLimit] = useState(25);
@@ -150,7 +151,10 @@ const SingleFund = ({
               <Button
                 className="w-full md:w-auto"
                 kind={Kind.PRIMARY}
-                href={`https://app.sushiswap.fi/token/${fundToken.address}`}
+                href={
+                  meta.buyUrl ||
+                  `https://app.sushiswap.fi/token/${fundToken.address}`
+                }
                 target="_blank"
                 icon={Icons.EXTERNAL_LINK}
               >

--- a/contexts/funds.tsx
+++ b/contexts/funds.tsx
@@ -2,11 +2,12 @@ import React, { useEffect, useState } from 'react';
 import { createContext, ReactChild, useContext } from 'react';
 import fetchWithTimeout from '@/utils/fetchWithTimeout';
 import { fundSymbols } from '@/constants/allowlist';
+import fundMeta from '@/constants/fundData.json';
 import { Fund } from '@/types/fund';
 
 const FundsContext = createContext<Fund[]>([]);
 
-const getFunds = async function (): Promise<Fund[]> {
+const getFunds = async function (): Promise<Omit<Fund, 'meta'>[]> {
   // fetch the latest funds data, cap at 5 seconds
   try {
     const res = await fetchWithTimeout('https://nftx.xyz/funds-data', {
@@ -34,7 +35,15 @@ export const FundsProvider = ({ children }: { children: ReactChild }) => {
       const filteredFunds = allFunds.filter(
         (f) => f.isFinalized && fundSymbols.includes(f.fundToken.symbol)
       );
-      setFunds(filteredFunds);
+      const withMeta = filteredFunds.map((f) => {
+        const meta = fundMeta.find((fm) => fm.vaultId === f.vaultId) || {};
+        return {
+          ...f,
+          meta,
+        };
+      });
+
+      setFunds(withMeta);
     })();
   }, []);
 

--- a/types/fund.ts
+++ b/types/fund.ts
@@ -16,4 +16,14 @@ export interface Fund {
   isD2Vault: boolean;
   isClosed: boolean;
   manager: string;
+  meta?: {
+    vaultId?: number;
+    name?: string;
+    imageIcon?: string;
+    imageFeature?: string;
+    description?: string;
+    buyUrl?: string;
+    buyOpenseaUrl?: string;
+    mintRedeemUrl?: string;
+  };
 }


### PR DESCRIPTION
Use the provided json "cms" content to create a meta object per fund and use this to select the buy URL per fund. Also use the image preview url on the vault cards to save bytes.