### PR TITLE
fix: add minimum fractional digits

### DIFF
--- a/components/GroupHeader/GroupHeader.tsx
+++ b/components/GroupHeader/GroupHeader.tsx
@@ -55,6 +55,7 @@ const FundGroupHeader = ({
                       value={price.raw * fund.holdings.length}
                       currency="USD"
                       maximumFractionDigits={0}
+                      minimumFractionDigits={0}
                     />
                   </span>
                 ),

--- a/hooks/usePrice.ts
+++ b/hooks/usePrice.ts
@@ -23,7 +23,8 @@ const usePrice = (address: string) => {
         usd: intl.formatNumber(latestPrice, {
           style: 'currency',
           currency: 'USD',
-          maximumFractionDigits: 0,
+          maximumFractionDigits: 2,
+          minimumFractionDigits: 0,
         }),
         raw: latestPrice,
       });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nftx-gallery",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "author": "NFTX Gallery Squad <>",
   "homepage": "https://github.com/NFTX-project/sp-nftx-gallery",


### PR DESCRIPTION
Currency formatting wasn't working on iOS since it also required the minimum digits being set.